### PR TITLE
fix: color from byLevel is not picked up properly

### DIFF
--- a/etc/sarif-to-slack.api.md
+++ b/etc/sarif-to-slack.api.md
@@ -32,6 +32,7 @@ export type ColorOptions = {
     default?: Color;
     byLevel?: ColorGroupByLevel;
     bySeverity?: ColorGroupBySeverity;
+    empty?: Color;
 };
 
 // @public

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@
  *   username: 'SARIF to Slack Bot',
  *   iconUrl: 'https://example.com/icon.png',
  *   color: {
+ *     default: new Color('failure'),
+ *     empty: new Color('success'),
  *     bySeverity: {
  *       critical: new Color('#ff0000'),
  *       high: new Color('#ff4500'),
@@ -30,7 +32,13 @@
  *       low: new Color('#ffff00'),
  *       none: new Color('#808080'),
  *       unknown: new Color('#800080'),
- *       empty: new Color('#d3d3d3'),
+ *     },
+ *     byLevel: {
+ *       error: new Color('#ff0000'),
+ *       warning: new Color('#ffa500'),
+ *       note: new Color('#ffff00'),
+ *       none: new Color('#808080'),
+ *       unknown: new Color('#800080'),
  *     },
  *   },
  *   sarif: {
@@ -75,6 +83,8 @@ export {
   ColorGroupByLevel,
   ColorGroupBySeverity
 } from './model/Color'
+export { SendIf } from './model/SendIf'
+export { SlackMessage } from './model/SlackMessage'
 export { SarifToSlackClient } from './SarifToSlackClient'
 export {
   FooterOptions,
@@ -86,7 +96,5 @@ export {
   RepresentationType,
   SarifFileExtension,
   SarifOptions,
-  SarifToSlackClientOptions,
-  SendIf,
-  SlackMessage,
+  SarifToSlackClientOptions
 } from './types'

--- a/src/model/Finding.ts
+++ b/src/model/Finding.ts
@@ -18,7 +18,7 @@ export type FindingOptions = {
  * This interface represents a finding from SARIF file.
  * @internal
  */
-export interface Finding {
+export default interface Finding {
   get sarifPath(): string,
   get runId(): number,
   get toolName(): string,
@@ -33,7 +33,7 @@ export interface Finding {
  * @internal
  */
 export function createFinding(opts: FindingOptions): Finding {
-  return new SarifFinding(opts)
+  return new FindingImpl(opts)
 }
 
 /**
@@ -42,7 +42,7 @@ export function createFinding(opts: FindingOptions): Finding {
  * create a new {@link Finding}.
  * @private
  */
-class SarifFinding implements Finding {
+class FindingImpl implements Finding {
   private readonly _runMetadata: RunData
   private readonly _result: Result
   private readonly _sarifPath: string

--- a/src/model/FindingArray.ts
+++ b/src/model/FindingArray.ts
@@ -1,13 +1,13 @@
-import { Finding } from './Finding'
-import ExtendedArray from '../utils/ExtendedArray'
+import Finding from './Finding'
 import { SecurityLevel, SecuritySeverity } from '../types'
+import ExtendedArray from '../utils/ExtendedArray'
 
 /**
  * This class represents an array of {@link Finding} objects and adds additional
  * useful methods to it.
  * @internal
  */
-export default class FindingsArray extends ExtendedArray<Finding> {
+export default class FindingArray extends ExtendedArray<Finding> {
 
   public hasSeverityOrHigher(severity: SecuritySeverity): boolean {
     return Object

--- a/src/model/SendIf.ts
+++ b/src/model/SendIf.ts
@@ -1,0 +1,175 @@
+/**
+ * This enum represents the condition on when message should be sent. If this
+ * condition is satisfied then message is sent, otherwise - message is not sent.
+ * @public
+ */
+export enum SendIf {
+  /**
+   * Send message only if there is at least one finding with "Critical" severity.
+   * Since it is the higher possible severity, it is the same as "Critical" or
+   * higher.
+   */
+  SeverityCritical,
+  /**
+   * Send message only if there is at least one finding with "High" severity.
+   */
+  SeverityHigh,
+  /**
+   * Send message only if there is at least one finding with "High" severity or
+   * higher, that includes "High" and "Critical".
+   */
+  SeverityHighOrHigher,
+  /**
+   * Send message only if there is at least one finding with "Medium" severity.
+   */
+  SeverityMedium,
+  /**
+   * Send message only if there is at least one finding with "Medium" severity
+   * or higher, that includes "Medium", "High" and "Critical".
+   */
+  SeverityMediumOrHigher,
+  /**
+   * Send message only if there is at least one finding with "Low" severity.
+   */
+  SeverityLow,
+  /**
+   * Send message only if there is at least one finding with "Low" severity or
+   * higher, that includes "Low", "Medium", "High" and "Critical".
+   */
+  SeverityLowOrHigher,
+  /**
+   * Send message only if there is at least one finding with "None" severity.
+   */
+  SeverityNone,
+  /**
+   * Send message only if there is at least one finding with "None" severity or
+   * higher, that includes "None", "Low", "Medium", "High" and "Critical".
+   */
+  SeverityNoneOrHigher,
+  /**
+   * Send message only if there is at least one finding with "Unknown" severity.
+   */
+  SeverityUnknown,
+  /**
+   * Send message only if there is at least one finding with "Unknown" severity
+   * or higher, that includes "Unknown", "None", "Low", "Medium", "High" and "Critical".
+   */
+  SeverityUnknownOrHigher,
+  /**
+   * Send message only if there is at least one finding with "Error" level.
+   * Since it is the higher possible level, it is the same as "Error" or higher.
+   */
+  LevelError,
+  /**
+   * Send message only if there is at least one finding with "Warning" level.
+   */
+  LevelWarning,
+  /**
+   * Send message only if there is at least one finding with "Warning" level or
+   * higher, that includes "Warning" and "Error".
+   */
+  LevelWarningOrHigher,
+  /**
+   * Send message only if there is at least one finding with "Note" level.
+   */
+  LevelNote,
+  /**
+   * Send message only if there is at least one finding with "Note" level or
+   * higher, that includes "Note", "Warning" and "Error.
+   */
+  LevelNoteOrHigher,
+  /**
+   * Send message only if there is at least one finding with "None" level.
+   */
+  LevelNone,
+  /**
+   * Send message only if there is at least one finding with "None" level or
+   * higher, that includes "None", "Note", "Warning" and "Error.
+   */
+  LevelNoneOrHigher,
+  /**
+   * Send message only if there is at least one finding with "Unknown" level.
+   */
+  LevelUnknown,
+  /**
+   * Send message only if there is at least one finding with "Unknown" level or
+   * higher, that includes "Unknown", "None", "Note", "Warning" and "Error.
+   */
+  LevelUnknownOrHigher,
+  /**
+   * Always send a message.
+   */
+  Always,
+  /**
+   * Send a message if at least 1 vulnerability is found.
+   */
+  Some,
+  /**
+   * Send a message only if no vulnerabilities are found.
+   */
+  Empty,
+  /**
+   * Never send a message.
+   */
+  Never,
+}
+
+/**
+ * Returns log message based on the provided {@param sendIf} parameter.
+ * @param sendIf An instance of {@link SendIf} enum.
+ * @internal
+ */
+export function sendIfLogMessage(sendIf: SendIf): string {
+  switch (sendIf) {
+    case SendIf.SeverityCritical:
+      return 'No message sent: no findings with "Critical" severity.'
+    case SendIf.SeverityHigh:
+      return 'No message sent: no findings with "High" severity.'
+    case SendIf.SeverityHighOrHigher:
+      return 'No message sent: no findings with "High" or higher severity.'
+    case SendIf.SeverityMedium:
+      return 'No message sent: no findings with "Medium" severity.'
+    case SendIf.SeverityMediumOrHigher:
+      return 'No message sent: no findings with "Medium" or higher severity.'
+    case SendIf.SeverityLow:
+      return 'No message sent: no findings with "Low" severity.'
+    case SendIf.SeverityLowOrHigher:
+      return 'No message sent: no findings with "Low" or higher severity.'
+    case SendIf.SeverityNone:
+      return 'No message sent: no findings with "None" severity.'
+    case SendIf.SeverityNoneOrHigher:
+      return 'No message sent: no findings with "None" or higher severity.'
+    case SendIf.SeverityUnknown:
+      return 'No message sent: no findings with "Unknown" severity.'
+    case SendIf.SeverityUnknownOrHigher:
+      return 'No message sent: no findings with "Unknown" or higher severity.'
+    case SendIf.LevelError:
+      return 'No message sent: no findings with "Error" level.'
+    case SendIf.LevelWarning:
+      return 'No message sent: no findings with "Warning" level.'
+    case SendIf.LevelWarningOrHigher:
+      return 'No message sent: no findings with "Warning" or higher level.'
+    case SendIf.LevelNote:
+      return 'No message sent: no findings with "Note" level.'
+    case SendIf.LevelNoteOrHigher:
+      return 'No message sent: no findings with "Note" or higher level.'
+    case SendIf.LevelNone:
+      return 'No message sent: no findings with "None" level.'
+    case SendIf.LevelNoneOrHigher:
+      return 'No message sent: no findings with "None" or higher level.'
+    case SendIf.LevelUnknown:
+      return 'No message sent: no findings with "Unknown" level.'
+    case SendIf.LevelUnknownOrHigher:
+      return 'No message sent: no findings with "Unknown" or higher level.'
+    case SendIf.Always:
+      return 'Message always sent.'
+    case SendIf.Some:
+      return 'No message sent: findings are not found.'
+    case SendIf.Empty:
+      return 'No message sent: some findings are found.'
+    case SendIf.Never:
+      return 'No message sent: sending is disabled.'
+    default:
+      return 'Unknown SendIf value.'
+  }
+}

--- a/src/processors/CodeQLProcessor.ts
+++ b/src/processors/CodeQLProcessor.ts
@@ -1,5 +1,5 @@
 import { CommonProcessor } from './CommonProcessor'
-import { Result } from 'sarif';
+import { Result } from 'sarif'
 
 /**
  * This class has extra logic for processing SARIF files produced by CodeQL tool.

--- a/src/representations/CompactGroupByRepresentation.ts
+++ b/src/representations/CompactGroupByRepresentation.ts
@@ -1,5 +1,5 @@
 import Representation from './Representation'
-import { Finding } from '../model/Finding'
+import Finding from '../model/Finding'
 import { findingsComparatorByKey } from '../utils/Comparators'
 import { SecurityLevel, SecuritySeverity } from '../types';
 

--- a/src/representations/CompactGroupByRunRepresentation.ts
+++ b/src/representations/CompactGroupByRunRepresentation.ts
@@ -1,4 +1,4 @@
-import { Finding } from '../model/Finding'
+import Finding from '../model/Finding'
 import CompactGroupByRepresentation from './CompactGroupByRepresentation'
 import { SarifModel } from '../types'
 

--- a/src/representations/CompactGroupBySarifRepresentation.ts
+++ b/src/representations/CompactGroupBySarifRepresentation.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { Finding } from '../model/Finding'
+import Finding from '../model/Finding'
 import CompactGroupByRepresentation from './CompactGroupByRepresentation'
 import { SarifModel } from '../types'
 

--- a/src/representations/CompactGroupByToolNameRepresentation.ts
+++ b/src/representations/CompactGroupByToolNameRepresentation.ts
@@ -1,4 +1,4 @@
-import { Finding } from '../model/Finding'
+import Finding from '../model/Finding'
 import CompactGroupByRepresentation from './CompactGroupByRepresentation'
 import { SarifModel } from '../types'
 

--- a/src/representations/CompactTotalRepresentation.ts
+++ b/src/representations/CompactTotalRepresentation.ts
@@ -1,5 +1,5 @@
 import CompactGroupByRepresentation from './CompactGroupByRepresentation'
-import { Finding } from '../model/Finding'
+import Finding from '../model/Finding'
 
 /**
  * Since {@link CompactGroupByRepresentation} already prepares compact representation

--- a/src/representations/Representation.ts
+++ b/src/representations/Representation.ts
@@ -1,7 +1,7 @@
 import { SarifModel } from '../types'
-import { Finding } from '../model/Finding'
+import Finding from '../model/Finding'
 import { findingsComparatorByKey } from '../utils/Comparators'
-import FindingsArray from '../model/FindingsArray'
+import FindingArray from '../model/FindingArray'
 
 /**
  * The most base abstract class for the representation. Every representation class
@@ -17,10 +17,10 @@ export default abstract class Representation {
       .findings
       .map((f: Finding): Finding => f.clone())
       .sort(findingsComparatorByKey(findingSortKey))
-      .reduce((arr: FindingsArray, f: Finding): FindingsArray => {
+      .reduce((arr: FindingArray, f: Finding): FindingArray => {
         arr.push(f)
         return arr
-      }, new FindingsArray())
+      }, new FindingArray())
   }
 
   protected bold(text: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,22 +1,7 @@
 import { Run } from 'sarif'
 import { ColorOptions } from './model/Color'
-import FindingsArray from './model/FindingsArray'
-
-/**
- * Interface for a Slack message that can be sent.
- * @public
- */
-export interface SlackMessage {
-  /**
-   * Sends the Slack message.
-   * @returns A promise that resolves to the response from the Slack webhook.
-   */
-  send: () => Promise<string>
-  withActor(actor?: string): void
-  withFooter(text?: string, type?: FooterType): void
-  withHeader(header?: string): void
-  withRun(): void
-}
+import FindingArray from './model/FindingArray'
+import { SendIf } from './model/SendIf'
 
 /**
  * Enum representing log levels for the service.
@@ -222,122 +207,6 @@ export type SarifOptions = {
 }
 
 /**
- * This enum represents the condition on when message should be sent. If this
- * condition is satisfied then message is sent, otherwise - message is not sent.
- * @public
- */
-export enum SendIf {
-  /**
-   * Send message only if there is at least one finding with "Critical" severity.
-   * Since it is the higher possible severity, it is the same as "Critical" or
-   * higher.
-   */
-  SeverityCritical,
-  /**
-   * Send message only if there is at least one finding with "High" severity.
-   */
-  SeverityHigh,
-  /**
-   * Send message only if there is at least one finding with "High" severity or
-   * higher, that includes "High" and "Critical".
-   */
-  SeverityHighOrHigher,
-  /**
-   * Send message only if there is at least one finding with "Medium" severity.
-   */
-  SeverityMedium,
-  /**
-   * Send message only if there is at least one finding with "Medium" severity
-   * or higher, that includes "Medium", "High" and "Critical".
-   */
-  SeverityMediumOrHigher,
-  /**
-   * Send message only if there is at least one finding with "Low" severity.
-   */
-  SeverityLow,
-  /**
-   * Send message only if there is at least one finding with "Low" severity or
-   * higher, that includes "Low", "Medium", "High" and "Critical".
-   */
-  SeverityLowOrHigher,
-  /**
-   * Send message only if there is at least one finding with "None" severity.
-   */
-  SeverityNone,
-  /**
-   * Send message only if there is at least one finding with "None" severity or
-   * higher, that includes "None", "Low", "Medium", "High" and "Critical".
-   */
-  SeverityNoneOrHigher,
-  /**
-   * Send message only if there is at least one finding with "Unknown" severity.
-   */
-  SeverityUnknown,
-  /**
-   * Send message only if there is at least one finding with "Unknown" severity
-   * or higher, that includes "Unknown", "None", "Low", "Medium", "High" and "Critical".
-   */
-  SeverityUnknownOrHigher,
-  /**
-   * Send message only if there is at least one finding with "Error" level.
-   * Since it is the higher possible level, it is the same as "Error" or higher.
-   */
-  LevelError,
-  /**
-   * Send message only if there is at least one finding with "Warning" level.
-   */
-  LevelWarning,
-  /**
-   * Send message only if there is at least one finding with "Warning" level or
-   * higher, that includes "Warning" and "Error".
-   */
-  LevelWarningOrHigher,
-  /**
-   * Send message only if there is at least one finding with "Note" level.
-   */
-  LevelNote,
-  /**
-   * Send message only if there is at least one finding with "Note" level or
-   * higher, that includes "Note", "Warning" and "Error.
-   */
-  LevelNoteOrHigher,
-  /**
-   * Send message only if there is at least one finding with "None" level.
-   */
-  LevelNone,
-  /**
-   * Send message only if there is at least one finding with "None" level or
-   * higher, that includes "None", "Note", "Warning" and "Error.
-   */
-  LevelNoneOrHigher,
-  /**
-   * Send message only if there is at least one finding with "Unknown" level.
-   */
-  LevelUnknown,
-  /**
-   * Send message only if there is at least one finding with "Unknown" level or
-   * higher, that includes "Unknown", "None", "Note", "Warning" and "Error.
-   */
-  LevelUnknownOrHigher,
-  /**
-   * Always send a message.
-   */
-  Always,
-  /**
-   * Send a message if at least 1 vulnerability is found.
-   */
-  Some,
-  /**
-   * Send a message only if no vulnerabilities are found.
-   */
-  Empty,
-  /**
-   * Never send a message.
-   */
-  Never,
-}
-
-/**
  * Options for the SarifToSlackClient.
  * @public
  */
@@ -405,5 +274,5 @@ export type RunData = {
 export type SarifModel = {
   sarifFiles: string[],
   runs: RunData[],
-  findings: FindingsArray,
+  findings: FindingArray,
 }

--- a/src/utils/Comparators.ts
+++ b/src/utils/Comparators.ts
@@ -1,4 +1,4 @@
-import { Finding } from '../model/Finding'
+import Finding from '../model/Finding'
 
 /**
  * This function returns a comparator function based on the property of the

--- a/tests/integration/SendSarifToSlack.spec.ts
+++ b/tests/integration/SendSarifToSlack.spec.ts
@@ -105,7 +105,6 @@ describe('(integration): SendSarifToSlack', (): void => {
           note: new Color(process.env.SARIF_TO_SLACK_COLOR_NOTE),
           none: new Color(process.env.SARIF_TO_SLACK_COLOR_NONE),
           unknown: new Color(process.env.SARIF_TO_SLACK_COLOR_UNKNOWN),
-          empty: new Color(process.env.SARIF_TO_SLACK_COLOR_EMPTY),
         },
         bySeverity: {
           critical: new Color(process.env.SARIF_TO_SLACK_COLOR_CRITICAL),
@@ -114,8 +113,8 @@ describe('(integration): SendSarifToSlack', (): void => {
           low: new Color(process.env.SARIF_TO_SLACK_COLOR_LOW),
           none: new Color(process.env.SARIF_TO_SLACK_COLOR_NONE),
           unknown: new Color(process.env.SARIF_TO_SLACK_COLOR_UNKNOWN),
-          empty: new Color(process.env.SARIF_TO_SLACK_COLOR_EMPTY),
         },
+        empty: new Color(process.env.SARIF_TO_SLACK_COLOR_EMPTY),
       },
       sarif: {
         path: process.env.SARIF_TO_SLACK_SARIF_PATH as string,


### PR DESCRIPTION
### Steps to reproduce

```typescript
const client: SarifToSlackClient = await SarifToSlackClient.create({
  webhookUrl: 'https://hooks.slack.com/services/your/webhook/url'
  color: {
    default: new Color('#ff4500'),
    byLevel: {
      note: new Color('#ffff00'),
    },
    bySeverity: {
      critical: new Color('#ff0000'),
    },
  },
  sarif: {
    path: 'path/to/your/file.sarif',
  }
})
```

`path/to/your/file.sarif` should have no results with "Critical" severity and at least 1 result with "Note" level.

### Expected behavior

Slack message should be sent with `#ffff00` color.

### Actual behavior

Slack message is sent with `#ff4500` color.